### PR TITLE
fix bundle install validation on .gemspec error

### DIFF
--- a/covertrace.gemspec
+++ b/covertrace.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Covertrace tracks the coverage of individual pieces of code}
   spec.description   = %q{Covertrace tracks the coverage of individual pieces of code}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/gmalette/covertrace"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or


### PR DESCRIPTION
I was getting this error when bundle exec-ing:
```
┃┏━━ Running `bundle install` 
┃┃ You have one or more invalid gemspecs that need to be fixed.
┃┃ The gemspec at /Users/????/.gem/ruby/2.4.3/bundler/gems/covertrace-b79567decf58/covertrace.gemspec is not valid. Please fix
┃┃ this gemspec.
┃┃ The validation error was '"TODO: Put your gem's website or public repo URL here." is not a valid HTTP URI'
```

ruby:
      version: 2.4.3
      rubygems: 2.7.6